### PR TITLE
Add initial support for Go LSP (gopls)

### DIFF
--- a/go-language-server/Dockerfile
+++ b/go-language-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as build
+FROM golang:1.16.4
 
 WORKDIR /go
 

--- a/go-language-server/Dockerfile
+++ b/go-language-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:latest as build
+
+WORKDIR /go
+
+RUN GO111MODULE=on go get golang.org/x/tools/gopls@latest
+
+CMD gopls


### PR DESCRIPTION
This is just the basic golang docker file with gopls installed. 

Right now it targets 1.16.4 but we could track latest as well if you wanted to keep it up to date automatically. Your call.

I didn't see a lot that needed done here, it was pretty straight forward with the official golang container. Let me know if you think anything needs to change or I missed something.