### PR TITLE
Fix missing build-base in clangd container

### DIFF
--- a/servers/clangd/Dockerfile
+++ b/servers/clangd/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.14
 
-RUN apk add --no-cache clang-extra-tools
+RUN apk add --no-cache build-base clang-extra-tools
 
 CMD [ "/usr/bin/clangd", "--background-index" ]


### PR DESCRIPTION
When adding clangd, I've forgotten to add "build-base". Without it, clangd is not able to resolve headers from standard library `#include <stdio.h>     ■ 'stdio.h' file not found`