### PR TITLE
fix(gopls): resolving git dependency issue

### DIFF
--- a/servers/gopls/Dockerfile
+++ b/servers/gopls/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.13.5
 
 RUN apk add --no-cache \
-  go
+  go \
+  git
 
 ENV GO111MODULE="on"
 


### PR DESCRIPTION
In its current state on build this image throws the following error:

```sh
go get golang.org/x/tools/gopls@v: git init --bare in /root/go/pkg/mod/cache/vcs/7d9b3b49b55db5b40e68a94007f21a05905d3fda866f685220de88f9c9bad98a: exec: "git": executable file not found in $PATH
```

To resolve this issue we've added `git` to the installed packages