### PR TITLE
Fix solargraph

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -84,6 +84,13 @@ services:
       args:
         VERSION: ${rust_analyzer}
 
+  solargraph:
+    image: lspcontainers/solargraph:${solargraph}
+    build:
+      context: servers/solargraph
+      args:
+        VERSION: ${solargraph}
+
   sumneko_lua:
     image: lspcontainers/lua-language-server:${sumneko_lua}
     build:

--- a/servers/solargraph/Dockerfile
+++ b/servers/solargraph/Dockerfile
@@ -3,5 +3,6 @@ FROM ruby:alpine
 ARG VERSION
 RUN apk add --no-cache build-base
 RUN gem install solargraph -v $VERSION
+RUN gem install solargraph-rails --pre
 
 CMD [ "solargraph", "stdio" ]

--- a/servers/solargraph/Dockerfile
+++ b/servers/solargraph/Dockerfile
@@ -1,8 +1,13 @@
-FROM ruby:alpine
+FROM ubuntu
 
 ARG VERSION
-RUN apk add --no-cache build-base
-RUN gem install solargraph -v $VERSION
-RUN gem install solargraph-rails --pre
+RUN apt update && apt upgrade -y
+RUN apt install software-properties-common -y
+RUN apt-add-repository -y ppa:rael-gc/rvm
+RUN apt update
+RUN apt install rvm -y
+RUN groupadd rvm
+RUN usermod -a -G rvm root
+COPY ./docker_entrypoint.sh /docker_entrypoint.sh
 
-CMD [ "solargraph", "stdio" ]
+CMD [ "/docker_entrypoint.sh" ]

--- a/servers/solargraph/Dockerfile
+++ b/servers/solargraph/Dockerfile
@@ -1,16 +1,7 @@
-FROM alpine:3.13.5
-
-RUN apk add --no-cache \
-  g++ \
-  gcc \
-  git \
-  make \
-  ruby \
-  ruby-dev \
-  zlib-dev
+FROM ruby:alpine
 
 ARG VERSION
-
+RUN apk add --no-cache build-base
 RUN gem install solargraph -v $VERSION
 
-CMD [ "/usr/local/bundle/bin/solargraph", "stdio" ]
+CMD [ "solargraph", "stdio" ]

--- a/servers/solargraph/docker_entrypoint.sh
+++ b/servers/solargraph/docker_entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "hello $@"
+
+# TODO:
+# 1. Create a rvm group and use it
+# 2. Install gems: bundler, solargraph and yard
+# 3. Run `bundle install` to install project dependencies
+# 4. Run `solargraph download-core` to download the core documentation
+# 5. Run `yard gems` to generate documentation for all dependencies
+# 6. Call $@ (mainly `solargraph stdio`)


### PR DESCRIPTION
I found two problems with Solargraph:

 1. The default install location was `/usr/bin/solargraph` not `/usr/local/bundle/bin/solargraph` so I changed that
 2. Some dependencies failed to build so I changed `alpine:3.13.5` as base to `ruby:alpine` and installed `build-base`

I also added it to `docker-compose.yml` and a very useful extension [solargraph-rails](https://github.com/iftheshoefritz/solargraph-rails)

Here's a picture of my `LspInfo` now:

![image](https://user-images.githubusercontent.com/58179604/142084230-dad222b4-6ecb-4691-a278-7dce11186f41.png)

Closes #60 