### PR TITLE
Use the rust-analyzer package from the alpine repo

### DIFF
--- a/servers/rust_analyzer/Dockerfile
+++ b/servers/rust_analyzer/Dockerfile
@@ -1,20 +1,14 @@
 FROM alpine:3.15.0
 
-RUN apk add --no-cache \
+RUN apk add -U --no-cache \
   bash \
   curl \
-  gcc
+  gcc \
+  cargo \
+  && rm -rf /var/cache/apk/*
 
-RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/sh.rustup.rs \
-  && chmod +x /tmp/sh.rustup.rs \
-  && /tmp/sh.rustup.rs --default-toolchain none -y \
-  && rm -rf /tmp/sh.rustup.rs \
-  && . "$HOME"/.cargo/env \
-  && rustup toolchain install nightly \
-  && rustup component add rust-analyzer-preview
+RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
-COPY ./docker_entrypoint.sh /docker_entrypoint.sh
+RUN apk add rust-analyzer@testing
 
-ENTRYPOINT [ "/docker_entrypoint.sh" ]
-
-CMD [ "/root/.rustup/toolchains/nightly-x86_64-unknown-linux-musl/bin/rust-analyzer" ]
+CMD [ "rust-analyzer" ]

--- a/servers/rust_analyzer/docker_entrypoint.sh
+++ b/servers/rust_analyzer/docker_entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -e
-
-source /root/.cargo/env \
-  && exec "$@"


### PR DESCRIPTION
The rust-analyzer binary is already in the edge/community package repository from Alpine. Using this package instead of the component from rustup makes the container 500 MB smaller and avoids using the nightly toolchain.