### PR TITLE
ci: add build steps for tailwindcss

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -64,6 +64,9 @@ jobs:
           - context: svelteserver
             tag: svelte-language-server
 
+          - context: tailwindcss
+            tag: tailwindcss-language-server
+
           - context: terraformls
             tag: terraform-ls
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -80,6 +80,11 @@ services:
     build:
       context: servers/svelteserver
 
+  tailwindcss:
+    image: lspcontainers/tailwindcss-language-server
+    build:
+      context: servers/tailwindcss
+
   terraformls:
     image: lspcontainers/terraform-ls
     build:


### PR DESCRIPTION
This adds the build steps for #74 that I missed out.