### PR TITLE
Update rust_analyzer Toolchain

### DIFF
--- a/servers/rust_analyzer/Dockerfile
+++ b/servers/rust_analyzer/Dockerfile
@@ -1,20 +1,19 @@
 FROM alpine:3.15.0
 
+ENV PATH "/root/.cargo/bin:/root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin:$PATH"
+
 RUN apk add --no-cache \
-  bash \
-  curl \
-  gcc
+    bash \
+    curl \
+    gcc
 
 RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/sh.rustup.rs \
-  && chmod +x /tmp/sh.rustup.rs \
-  && /tmp/sh.rustup.rs --default-toolchain none -y \
-  && rm -rf /tmp/sh.rustup.rs \
-  && . "$HOME"/.cargo/env \
-  && rustup toolchain install nightly \
-  && rustup component add rust-analyzer-preview
+    && chmod +x /tmp/sh.rustup.rs \
+    && /tmp/sh.rustup.rs --default-toolchain none -y \
+    && rm -rf /tmp/sh.rustup.rs \
+    && . "$HOME"/.cargo/env \
+    && rustup toolchain install stable \
+    && rustup component add rust-analyzer \
+    && rustup component add rust-src
 
-COPY ./docker_entrypoint.sh /docker_entrypoint.sh
-
-ENTRYPOINT [ "/docker_entrypoint.sh" ]
-
-CMD [ "/root/.rustup/toolchains/nightly-x86_64-unknown-linux-musl/bin/rust-analyzer" ]
+CMD [ "rust-analyzer" ]

--- a/servers/rust_analyzer/docker_entrypoint.sh
+++ b/servers/rust_analyzer/docker_entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -e
-
-source /root/.cargo/env \
-  && exec "$@"


### PR DESCRIPTION
## Overview

When setting up `rust_analyzer` we use the rustup tool to install specific versions and components of rust including the language server. Now that rust_analyzer is stable we should use the recommended setup from the official docs: https://rust-analyzer.github.io/manual.html#rustup

## Changes

- uses the `stable` toolchain
- adds missing `rust-src` component for `rust-analzyer`
- adds `PATH` for toolchain and language server binaries
- removes no longer needed `docker_entrypoint.sh`