### PR TITLE
Improve rust_analyzer Dockerfile

### DIFF
--- a/servers/rust_analyzer/Dockerfile
+++ b/servers/rust_analyzer/Dockerfile
@@ -1,11 +1,21 @@
 FROM alpine:3.15.0
 
-ENV PATH "/root/.cargo/bin:/root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin:$PATH"
-
 RUN apk add --no-cache \
     bash \
     curl \
-    gcc
+    gcc \
+    shadow \
+    sudo
+
+RUN userdel guest \
+    && groupdel users \
+    && addgroup lspcontainers \
+    && adduser -G lspcontainers -h /home/lspcontainers -D lspcontainers \
+    && echo '%lspcontainers ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/lspcontainers
+
+USER lspcontainers
+
+ENV PATH "/home/lspcontainers/.cargo/bin:/home/lspcontainers/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin:$PATH"
 
 RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/sh.rustup.rs \
     && chmod +x /tmp/sh.rustup.rs \
@@ -14,6 +24,8 @@ RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/sh.rustup.
     && . "$HOME"/.cargo/env \
     && rustup toolchain install stable \
     && rustup component add rust-analyzer \
-    && rustup component add rust-src
+    rust-src
 
-CMD [ "rust-analyzer" ]
+COPY docker_entrypoint.sh /home/lspcontainers/docker_entrypoint.sh
+
+ENTRYPOINT [ "/home/lspcontainers/docker_entrypoint.sh" ]

--- a/servers/rust_analyzer/docker_entrypoint.sh
+++ b/servers/rust_analyzer/docker_entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eu pipefail
+
+LSPCONTAINERS_GROUP=$(id -g)
+LSPCONTAINERS_USER=$(id -u)
+
+sudo usermod -u $LSPCONTAINERS_USER lspcontainers \
+    && sudo groupmod -g $LSPCONTAINERS_GROUP lspcontainers || true \
+    && exec "rust-analyzer"


### PR DESCRIPTION
## Overview

We have a common problem with some language servers which is they require the file system to read and or write data which includes permissions. This language server and `gopls` have the same problem.

## Changes

To try and improve on this - I have simplified the `docker_entrypoint.sh` to only focus on updating the user and silently fail if the group can't update. I have also standardized both language server images to use the same user and commands.