### PR TITLE
add denols

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,11 @@ services:
     build:
       context: servers/clangd
 
+  denols:
+    image: lspcontainers/denols
+    build:
+      context: servers/denols
+
   dockerls:
     image: lspcontainers/docker-language-server
     build:

--- a/servers/denols/Dockerfile
+++ b/servers/denols/Dockerfile
@@ -1,0 +1,3 @@
+FROM denoland/deno:alpine
+
+CMD [ "lsp" ]


### PR DESCRIPTION
Not sure if this is the preferred way, but it seemed better (simpler and less to have to keep in sync) to just derive from an official denoland image rather than to copy+tweak their Dockerfile.

Related plugin support added here: https://github.com/lspcontainers/lspcontainers.nvim/pull/98