### PR TITLE
Simply rust-analyzer Docker file

### DIFF
--- a/servers/rust_analyzer/Dockerfile
+++ b/servers/rust_analyzer/Dockerfile
@@ -1,31 +1,5 @@
-FROM alpine:3.15.0
+FROM rustlang/rust:nightly
 
-RUN apk add --no-cache \
-    bash \
-    curl \
-    gcc \
-    shadow \
-    sudo
+RUN rustup component add rust-analyzer
 
-RUN userdel guest \
-    && groupdel users \
-    && addgroup lspcontainers \
-    && adduser -G lspcontainers -h /home/lspcontainers -D lspcontainers \
-    && echo '%lspcontainers ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/lspcontainers
-
-USER lspcontainers
-
-ENV PATH "/home/lspcontainers/.cargo/bin:/home/lspcontainers/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin:$PATH"
-
-RUN curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/sh.rustup.rs \
-    && chmod +x /tmp/sh.rustup.rs \
-    && /tmp/sh.rustup.rs --default-toolchain none -y \
-    && rm -rf /tmp/sh.rustup.rs \
-    && . "$HOME"/.cargo/env \
-    && rustup toolchain install stable \
-    && rustup component add rust-analyzer \
-    rust-src
-
-COPY docker_entrypoint.sh /home/lspcontainers/docker_entrypoint.sh
-
-ENTRYPOINT [ "/home/lspcontainers/docker_entrypoint.sh" ]
+CMD [ "rust-analyzer" ]

--- a/servers/rust_analyzer/docker_entrypoint.sh
+++ b/servers/rust_analyzer/docker_entrypoint.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -eu pipefail
-
-LSPCONTAINERS_GROUP=$(id -g)
-LSPCONTAINERS_USER=$(id -u)
-
-sudo usermod -u $LSPCONTAINERS_USER lspcontainers \
-    && sudo groupmod -g $LSPCONTAINERS_GROUP lspcontainers || true \
-    && exec "rust-analyzer"


### PR DESCRIPTION
Currently the rust-analyzer dockerfile just installs the full nightly toolchain anyway, so we should use the language provided base image