### PR TITLE
fix(bashls): add missing shellcheck to bash lsp

### DIFF
--- a/servers/bashls/Dockerfile
+++ b/servers/bashls/Dockerfile
@@ -1,9 +1,13 @@
 FROM alpine:3.15.0
 
+# using npm breaks shellcheck download of its binary from api.github.com
+# running shellcheck -V forces it to download its binary during build
 RUN apk add --no-cache \
   nodejs \
-  npm \
-  && npm install -g \
-    bash-language-server
+  yarn \
+  && yarn global add \
+    shellcheck \
+    bash-language-server \
+  && shellcheck -V
 
 CMD [ "bash-language-server", "start" ]


### PR DESCRIPTION
Bash LSP was not working for me without `shellcheck` installed in the container. It turned out that simply installing it with `npm -g install shellcheck` is broken as well, as shellcheck tries to download its own binary from `api.github.com` and DNS resolving of that breaks in npm.

Anyway, with this PR is works beautifully now.