### PR TITLE
typescript: add vue plugin

### DIFF
--- a/servers/tsserver/Dockerfile
+++ b/servers/tsserver/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache \
   npm \
   && npm install -g \
     typescript-language-server \
+    @vue/typescript-plugin \
     typescript
 
 CMD [ "typescript-language-server", "--stdio" ]


### PR DESCRIPTION
This plugin is required by typescript-language-server to properly parse and handle Vue files.

This is not required in many use cases, so I'm not sure if you want to have this upstream.